### PR TITLE
fix(ui): Switch and ToggleButton style names

### DIFF
--- a/example.py
+++ b/example.py
@@ -131,11 +131,11 @@ accentbutton = ttk.Button(widgets_frame, text="Accentbutton", style="Accent.TBut
 accentbutton.grid(row=7, column=0, padx=5, pady=10, sticky="nsew")
 
 # Togglebutton
-button = ttk.Checkbutton(widgets_frame, text="Togglebutton", style="ToggleButton")
+button = ttk.Checkbutton(widgets_frame, text="Togglebutton", style="Toggle.TButton")
 button.grid(row=8, column=0, padx=5, pady=10, sticky="nsew")
 
 # Switch
-switch = ttk.Checkbutton(widgets_frame, text="Switch", style="Switch")
+switch = ttk.Checkbutton(widgets_frame, text="Switch", style="Switch.TCheckbutton")
 switch.grid(row=9, column=0, padx=5, pady=10, sticky="nsew")
 
 # Panedwindow

--- a/forest-dark.tcl
+++ b/forest-dark.tcl
@@ -109,7 +109,7 @@ namespace eval ttk::theme::forest-dark {
             }
         }
 
-        ttk::style layout Switch {
+        ttk::style layout Switch.TCheckbutton {
             Switch.button -children {
                 Switch.padding -children {
                     Switch.indicator -side left
@@ -118,7 +118,7 @@ namespace eval ttk::theme::forest-dark {
             }
         }
 
-        ttk::style layout ToggleButton {
+        ttk::style layout Toggle.TButton {
             ToggleButton.button -children {
                 ToggleButton.padding -children {
                     ToggleButton.label -side left -expand true

--- a/forest-light.tcl
+++ b/forest-light.tcl
@@ -109,7 +109,7 @@ namespace eval ttk::theme::forest-light {
             }
         }
 
-        ttk::style layout Switch {
+        ttk::style layout Switch.TCheckbutton {
             Switch.button -children {
                 Switch.padding -children {
                     Switch.indicator -side left
@@ -118,7 +118,7 @@ namespace eval ttk::theme::forest-light {
             }
         }
 
-        ttk::style layout ToggleButton {
+        ttk::style layout Toggle.TButton {
             ToggleButton.button -children {
                 ToggleButton.padding -children {
                     ToggleButton.label -side left -expand true


### PR DESCRIPTION
Make Switch and ToggleButton consistent with Sun-Valley and Azure themes.
Also help to integrate other themes like [tcl-awthemes](https://sourceforge.net/projects/tcl-awthemes/).